### PR TITLE
Update settings import and config

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,9 +1,6 @@
 from pathlib import Path
 from dotenv import load_dotenv
 
-# Import settings to ensure environment variables are loaded once
-from app.core.settings import settings  # noqa: F401
-
 # Construct the path to the .env file in the project root
 # __file__ is the path to app/__init__.py
 # Path(__file__).resolve().parent is the 'app' directory
@@ -11,3 +8,6 @@ from app.core.settings import settings  # noqa: F401
 env_path = Path(__file__).resolve().parent.parent / ".env"
 if env_path.is_file():
     load_dotenv(dotenv_path=env_path, override=True)
+
+# Import settings after environment variables are loaded
+from app.core.settings import settings  # noqa: F401

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -5,7 +5,8 @@ from pathlib import Path
 from typing import Optional
 
 from dotenv import load_dotenv
-from pydantic import BaseSettings, Field
+from pydantic_settings import BaseSettings
+from pydantic import Field
 
 # Load environment variables from project root .env if present
 ENV_PATH = Path(__file__).resolve().parents[2] / ".env"
@@ -18,9 +19,12 @@ class Settings(BaseSettings):
     redis_url: str = Field(default="redis://localhost:6379", alias="REDIS_URL")
     cache_ttl_sec: int = Field(default=3600, alias="CACHE_TTL_SEC")
     router_conf_threshold: float = Field(default=0.6, alias="ROUTER_CONF_THRESHOLD")
+    use_enhanced_log_analysis: bool = Field(default=True, alias="USE_ENHANCED_LOG_ANALYSIS")
+    enhanced_log_model: str = Field(default="gemini-2.5-pro", alias="ENHANCED_LOG_MODEL")
 
     class Config:
         case_sensitive = False
+        env_file = ENV_PATH
 
 @lru_cache()
 def get_settings() -> Settings:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ fastapi==0.115.12
 uvicorn
 python-multipart
 pydantic==2.11.5
+pydantic-settings
 python-dotenv
 
 # Langchain Stack


### PR DESCRIPTION
## Summary
- fix BaseSettings import to use `pydantic-settings`
- load `.env` before importing settings
- add Enhanced Log Analysis configuration fields
- include `pydantic-settings` in dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv', langchain_core, fastapi, requests, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685a397237a883328040aea3fe162d42