### PR TITLE
Clean unused imports and types

### DIFF
--- a/frontend/components/chat/MessageBubble.tsx
+++ b/frontend/components/chat/MessageBubble.tsx
@@ -32,7 +32,6 @@ import {
 import { cn } from '@/lib/utils'
 import { toast } from 'sonner'
 import { EnhancedLogAnalysisContainer } from '@/components/log-analysis/EnhancedLogAnalysisContainer'
-import { LogAnalysisContainer } from '@/components/log-analysis/LogAnalysisContainer'
 import { type LogAnalysisData, type EnhancedLogAnalysisData } from '@/lib/log-analysis-utils'
 import { ExecutiveSummaryRenderer } from '@/components/markdown/ExecutiveSummaryRenderer'
 

--- a/frontend/components/log-analysis/CorrelationAnalysisCard.tsx
+++ b/frontend/components/log-analysis/CorrelationAnalysisCard.tsx
@@ -24,24 +24,9 @@ interface CorrelationAnalysisCardProps {
   className?: string
 }
 
-interface CorrelationNode {
-  id: string
-  label: string
-  strength: number
-  type: 'temporal' | 'account' | 'issue_type'
-  metadata?: Record<string, any>
-}
-
-interface CorrelationEdge {
-  source: string
-  target: string
-  strength: number
-  correlation_type: string
-  confidence: number
-}
 
 export function CorrelationAnalysisCard({ analysis, className }: CorrelationAnalysisCardProps) {
-  const [selectedTab, setSelectedTab] = useState<'temporal' | 'account' | 'issue_type'>('temporal')
+  const [selectedTab, setSelectedTab] = useState<string>('temporal')
   const [showDetails, setShowDetails] = useState(false)
   
   if (!analysis || !analysis.analysis_summary) {
@@ -159,7 +144,7 @@ export function CorrelationAnalysisCard({ analysis, className }: CorrelationAnal
         </div>
 
         {/* Correlation Type Tabs */}
-        <Tabs value={selectedTab} onValueChange={setSelectedTab as (value: string) => void} className="w-full">
+        <Tabs value={selectedTab} onValueChange={setSelectedTab} className="w-full">
           <TabsList className="grid w-full grid-cols-3">
             <TabsTrigger value="temporal" className="flex items-center gap-2">
               <Clock className="h-3 w-3" />

--- a/frontend/components/log-analysis/DependencyAnalysisCard.tsx
+++ b/frontend/components/log-analysis/DependencyAnalysisCard.tsx
@@ -26,23 +26,9 @@ interface DependencyAnalysisCardProps {
   className?: string
 }
 
-interface DependencyNode {
-  id: string
-  label: string
-  type: 'root_cause' | 'symptom' | 'intermediate'
-  centrality_score?: number
-  impact_level?: string
-}
-
-interface DependencyEdge {
-  source: string
-  target: string
-  relationship_type: string
-  strength: number
-}
 
 export function DependencyAnalysisCard({ analysis, className }: DependencyAnalysisCardProps) {
-  const [selectedTab, setSelectedTab] = useState<'overview' | 'relationships' | 'cycles'>('overview')
+  const [selectedTab, setSelectedTab] = useState<string>('overview')
   const [showDetails, setShowDetails] = useState(false)
   
   if (!analysis || !analysis.graph_summary) {
@@ -158,7 +144,7 @@ export function DependencyAnalysisCard({ analysis, className }: DependencyAnalys
         </div>
 
         {/* Analysis Tabs */}
-        <Tabs value={selectedTab} onValueChange={setSelectedTab as (value: string) => void} className="w-full">
+        <Tabs value={selectedTab} onValueChange={setSelectedTab} className="w-full">
           <TabsList className="grid w-full grid-cols-3">
             <TabsTrigger value="overview" className="flex items-center gap-2">
               <Eye className="h-3 w-3" />

--- a/frontend/components/log-analysis/IssueCard.tsx
+++ b/frontend/components/log-analysis/IssueCard.tsx
@@ -15,17 +15,14 @@ import {
   Clock
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { 
+import {
   type LogIssue,
-  type LogSolution,
-  type EnhancedSolution, 
   severityClasses
 } from '@/lib/log-analysis-utils'
 import { SeverityBadge } from './SeverityBadge'
 
 interface IssueCardProps {
   issue: LogIssue
-  solutions?: Array<LogSolution | EnhancedSolution>  // Add solutions property for compatibility
   isExpanded?: boolean
   onToggle?: () => void
 }


### PR DESCRIPTION
## Summary
- remove unused `LogAnalysisContainer` import
- delete unused Correlation and Dependency interfaces
- drop unused `solutions` prop
- update Tabs handlers to avoid type casting

## Testing
- `npm test --silent` *(fails: Failed to resolve import '@/lib/utils')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685bd1eb08dc8332a0d98f12d1e5fd9b